### PR TITLE
Create a reproducible repo.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=	cassandra
-DISTVERSION=	4.0.5
+DISTVERSION=	4.0.8
 CATEGORIES=	databases java
 MASTER_SITES=	https://archive.apache.org/dist/${PORTNAME}/${DISTVERSION}/:apache \
 		https://repo1.maven.org/maven2/com/github/luben/zstd-jni/1.5.0-4/:maven

--- a/Makefile
+++ b/Makefile
@@ -103,8 +103,6 @@ pre-fetch:
 		> maven-offline-cache.mtree
 	cd ${WRKDIR} && ${TAR} cJf ${DISTDIR}/${DIST_SUBDIR}/${MAVEN_CACHE_FILE} \
 		@maven-offline-cache.mtree
-#TODO: debug, remove
-	ls -al ${DISTDIR}/${DIST_SUBDIR}/${MAVEN_CACHE_FILE}
 	${SHA256} ${WRKDIR}/maven-offline-cache.mtree ${DISTDIR}/${DIST_SUBDIR}/${MAVEN_CACHE_FILE}
 .endif
 

--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,9 @@ PKGNAMESUFFIX=	4
 DISTNAME=	apache-${PORTNAME}-${DISTVERSION}-src
 DISTFILES=	${DISTNAME}.tar.gz:apache \
 		${ZSTD_DISTFILE} \
-		apache-${PORTNAME}-${DISTVERSION}-repo.tar.gz:repo
+		apache-${PORTNAME}-${DISTVERSION}-repo.tar.xz:repo
 EXTRACT_ONLY=	${DISTNAME}.tar.gz \
-		apache-${PORTNAME}-${DISTVERSION}-repo.tar.gz
+		apache-${PORTNAME}-${DISTVERSION}-repo.tar.xz
 
 MAINTAINER=	language.devel@gmail.com
 COMMENT=	Highly scalable distributed database
@@ -88,7 +88,9 @@ pre-fetch:
 	${CP} ${FILESDIR}/maven/build-* ${WRKSRC}/.build
 	cd ${WRKSRC} && ${ANT} -Dmaven.repo.local=${REPO_DIR} -Dlocal.repository=${REPO_DIR} ${USEJDK11} resolver-dist-lib
 	cd ${REPO_DIR} && ${FIND} . -type f -name "*.repositories" -a -exec ${SED} -i '' -e '2s,.*,Mon Aug 08 20:40:04 CEST 2022,' {} +
-	cd ${WRKDIR} && ${TAR} czf ${DISTDIR}/apache-${PORTNAME}-${DISTVERSION}-repo.tar.gz repository/
+	cd ${REPO_DIR} && ${FIND} . -print0 | xargs -0 touch -d 2022-08-08T20:40:04Z
+	cd ${WRKDIR} && ${FIND} -s repository/ -print >list.txt && \
+            ${TAR} cJf ${DISTDIR}/apache-${PORTNAME}-${DISTVERSION}-repo.tar.xz -nT list.txt
 	${RM} -r ${WRKDIR}
 
 do-build:

--- a/Makefile
+++ b/Makefile
@@ -182,7 +182,7 @@ ZSTD_DISTFILE=
 post-install:
 	${LN} -s ${JAVAJARDIR}/netty.jar ${STAGEDIR}${DATADIR}/lib/netty.jar
 .if ${ARCH} == amd64 || ${ARCH} == i386
-	${CP} ${DISTDIR}/zstd-jni-${ZSTDJNI_VERSION}-freebsd_${ARCH}.jar ${STAGEDIR}${DATADIR}/lib/
+	${CP} ${DISTDIR}/${DIST_SUBDIR}/zstd-jni-${ZSTDJNI_VERSION}-freebsd_${ARCH}.jar ${STAGEDIR}${DATADIR}/lib/
 .endif
 
 post-install-DOCS-on:

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ PKGNAMESUFFIX=	4
 DISTNAME=	apache-${PORTNAME}-${DISTVERSION}-src
 DISTFILES=	${DISTNAME}.tar.gz:apache \
 		${ZSTD_DISTFILE} \
-		${MAVEN_CACHE_FILE}:repo
+		${MAVEN_CACHE_FILE}:prefetch
 DIST_SUBDIR=	${PORTNAME}
 EXTRACT_ONLY=	${DISTNAME}.tar.gz \
 		${MAVEN_CACHE_FILE}
@@ -69,7 +69,7 @@ SCRIPT_FILES=	cassandra \
 		sstableutil \
 		sstableverify
 
-ZSTDJNI_VERSION=${MASTER_SITES:M*\:maven:H:T}
+ZSTDJNI_VERSION=	${MASTER_SITES:M*\:maven:H:T}
 PLIST_SUB=	DISTVERSION=${DISTVERSION} ZSTDJNI_VERSION=${ZSTDJNI_VERSION}
 
 OPTIONS_DEFINE=		SIGAR DOCS
@@ -103,7 +103,9 @@ pre-fetch:
 		> maven-offline-cache.mtree
 	cd ${WRKDIR} && ${TAR} cJf ${DISTDIR}/${DIST_SUBDIR}/${MAVEN_CACHE_FILE} \
 		@maven-offline-cache.mtree
-	ls -al ${DISTDIR}/${DIST_SUBDIR}/apache-${PORTNAME}-${DISTVERSION}-repo.tar.xz
+#TODO: debug, remove
+	ls -al ${DISTDIR}/${DIST_SUBDIR}/${MAVEN_CACHE_FILE}
+	${SHA256} ${WRKDIR}/maven-offline-cache.mtree ${DISTDIR}/${DIST_SUBDIR}/${MAVEN_CACHE_FILE}
 .endif
 
 do-build:

--- a/distinfo
+++ b/distinfo
@@ -1,9 +1,7 @@
-TIMESTAMP = 1659987276
-SHA256 (apache-cassandra-4.0.5-src.tar.gz) = 9d79bcd8a9791436ded40b3e4d4c4b9d3bda77ab16d57059d1883e3ee99587aa
-SIZE (apache-cassandra-4.0.5-src.tar.gz) = 12872179
-SHA256 (zstd-jni-1.5.0-4-freebsd_amd64.jar) = b653460b6ff374db2c01f39a7b7cdb44008c9efd55dc96ae5f869abe9f58d180
-SIZE (zstd-jni-1.5.0-4-freebsd_amd64.jar) = 670993
-SHA256 (zstd-jni-1.5.0-4-freebsd_i386.jar) = 1bcb75c5837e42d10ec0193ba9df099874792f0829b0ce8dd3412303c6454595
-SIZE (zstd-jni-1.5.0-4-freebsd_i386.jar) = 604557
-SHA256 (apache-cassandra-4.0.5-repo.tar.gz) = f2c6dd937b953762f3a6aa1b7e04ead1ae636d376e5d08f703ce668a521e1835
-SIZE (apache-cassandra-4.0.5-repo.tar.gz) = 81273048
+TIMESTAMP = 1678485438
+SHA256 (cassandra/apache-cassandra-4.0.5-src.tar.gz) = 9d79bcd8a9791436ded40b3e4d4c4b9d3bda77ab16d57059d1883e3ee99587aa
+SIZE (cassandra/apache-cassandra-4.0.5-src.tar.gz) = 12872179
+SHA256 (cassandra/zstd-jni-1.5.0-4-freebsd_amd64.jar) = b653460b6ff374db2c01f39a7b7cdb44008c9efd55dc96ae5f869abe9f58d180
+SIZE (cassandra/zstd-jni-1.5.0-4-freebsd_amd64.jar) = 670993
+SHA256 (cassandra/apache-cassandra-4.0.5-repo.tar.xz) = e11d49fa71376bb31de041b54c51ec1ea077afe511d3b28b5479afcc41075e0f
+SIZE (cassandra/apache-cassandra-4.0.5-repo.tar.xz) = 78033936

--- a/distinfo
+++ b/distinfo
@@ -1,9 +1,9 @@
-TIMESTAMP = 1678487126
+TIMESTAMP = 1679924890
 SHA256 (cassandra/apache-cassandra-4.0.8-src.tar.gz) = 98da97d7fe850a0a24eb2aef212e982f73205cbd63955d2915b4ad02e28dae9c
 SIZE (cassandra/apache-cassandra-4.0.8-src.tar.gz) = 12953548
 SHA256 (cassandra/zstd-jni-1.5.0-4-freebsd_amd64.jar) = b653460b6ff374db2c01f39a7b7cdb44008c9efd55dc96ae5f869abe9f58d180
 SIZE (cassandra/zstd-jni-1.5.0-4-freebsd_amd64.jar) = 670993
 SHA256 (cassandra/zstd-jni-1.5.0-4-freebsd_i386.jar) = 1bcb75c5837e42d10ec0193ba9df099874792f0829b0ce8dd3412303c6454595
 SIZE (cassandra/zstd-jni-1.5.0-4-freebsd_i386.jar) = 604557
-SHA256 (cassandra/apache-cassandra-4.0.8-repo.tar.xz) = c31de1ecb1acd6865b1e4485d4b9b3dbf86fec2a38e9e789bb3ade97d898ef16
-SIZE (cassandra/apache-cassandra-4.0.8-repo.tar.xz) = 78382652
+SHA256 (cassandra/apache-cassandra-4.0.8-repo.tar.xz) = 807a108e3639f247dafa3ce4ebc4744b93668cf463915edf7b654d317d1abaff
+SIZE (cassandra/apache-cassandra-4.0.8-repo.tar.xz) = 78148020

--- a/distinfo
+++ b/distinfo
@@ -1,7 +1,7 @@
-TIMESTAMP = 1678485438
-SHA256 (cassandra/apache-cassandra-4.0.5-src.tar.gz) = 9d79bcd8a9791436ded40b3e4d4c4b9d3bda77ab16d57059d1883e3ee99587aa
-SIZE (cassandra/apache-cassandra-4.0.5-src.tar.gz) = 12872179
+TIMESTAMP = 1678487126
+SHA256 (cassandra/apache-cassandra-4.0.8-src.tar.gz) = 98da97d7fe850a0a24eb2aef212e982f73205cbd63955d2915b4ad02e28dae9c
+SIZE (cassandra/apache-cassandra-4.0.8-src.tar.gz) = 12953548
 SHA256 (cassandra/zstd-jni-1.5.0-4-freebsd_amd64.jar) = b653460b6ff374db2c01f39a7b7cdb44008c9efd55dc96ae5f869abe9f58d180
 SIZE (cassandra/zstd-jni-1.5.0-4-freebsd_amd64.jar) = 670993
-SHA256 (cassandra/apache-cassandra-4.0.5-repo.tar.xz) = e11d49fa71376bb31de041b54c51ec1ea077afe511d3b28b5479afcc41075e0f
-SIZE (cassandra/apache-cassandra-4.0.5-repo.tar.xz) = 78033936
+SHA256 (cassandra/apache-cassandra-4.0.8-repo.tar.xz) = c31de1ecb1acd6865b1e4485d4b9b3dbf86fec2a38e9e789bb3ade97d898ef16
+SIZE (cassandra/apache-cassandra-4.0.8-repo.tar.xz) = 78382652

--- a/distinfo
+++ b/distinfo
@@ -3,5 +3,7 @@ SHA256 (cassandra/apache-cassandra-4.0.8-src.tar.gz) = 98da97d7fe850a0a24eb2aef2
 SIZE (cassandra/apache-cassandra-4.0.8-src.tar.gz) = 12953548
 SHA256 (cassandra/zstd-jni-1.5.0-4-freebsd_amd64.jar) = b653460b6ff374db2c01f39a7b7cdb44008c9efd55dc96ae5f869abe9f58d180
 SIZE (cassandra/zstd-jni-1.5.0-4-freebsd_amd64.jar) = 670993
+SHA256 (cassandra/zstd-jni-1.5.0-4-freebsd_i386.jar) = 1bcb75c5837e42d10ec0193ba9df099874792f0829b0ce8dd3412303c6454595
+SIZE (cassandra/zstd-jni-1.5.0-4-freebsd_i386.jar) = 604557
 SHA256 (cassandra/apache-cassandra-4.0.8-repo.tar.xz) = c31de1ecb1acd6865b1e4485d4b9b3dbf86fec2a38e9e789bb3ade97d898ef16
 SIZE (cassandra/apache-cassandra-4.0.8-repo.tar.xz) = 78382652

--- a/files/maven/build-resolver.xml
+++ b/files/maven/build-resolver.xml
@@ -60,7 +60,7 @@
 
         <macrodef name="resolve">
             <!--
-              maven-resolver-ant-tasks's resolve logic doesn't have retry logic and does not respect settings.xml, 
+              maven-resolver-ant-tasks's resolve logic doesn't have retry logic and does not respect settings.xml,
               this causes issues when overriding maven central is required (such as when behind a corporate firewall);
               it is critical to always provide the 'all' remoterepos to override resolve's default hard coded logic.
 
@@ -227,7 +227,7 @@
             <url url="${lib.download.base.url}/lib/sigar-bin/sigar-x86-winnt.dll"/>
             <url url="${lib.download.base.url}/lib/sigar-bin/sigar-x86-winnt.lib"/>
         </get>
-        
+
         <copy todir="${build.lib}" quiet="true">
             <file file="${local.repository}/org/apache/cassandra/deps/futures-2.1.6-py2.py3-none-any.zip"/>
             <file file="${local.repository}/org/apache/cassandra/deps/six-1.12.0-py2.py3-none-any.zip"/>

--- a/files/maven/build.xml
+++ b/files/maven/build.xml
@@ -544,7 +544,7 @@
             <exclusion groupId="com.google.guava" artifactId="guava"/>
           </dependency>
           <dependency groupId="org.apache.cassandra" artifactId="dtest-api" version="0.0.13" scope="test"/>
-          <dependency groupId="org.reflections" artifactId="reflections" version="0.9.12" scope="test"/>
+          <dependency groupId="org.reflections" artifactId="reflections" version="0.10.2" scope="test"/>
           <dependency groupId="org.apache.hadoop" artifactId="hadoop-core" version="1.0.3" scope="provided">
             <exclusion groupId="org.mortbay.jetty" artifactId="servlet-api"/>
             <exclusion groupId="commons-logging" artifactId="commons-logging"/>

--- a/files/maven/build.xml
+++ b/files/maven/build.xml
@@ -913,7 +913,7 @@
     <property name="stress.test.src" value="${basedir}/tools/stress/test/unit" />
     <property name="stress.build.classes" value="${build.classes}/stress" />
     <property name="stress.test.classes" value="${build.dir}/test/stress-classes" />
-	<property name="stress.manifest" value="${stress.build.classes}/MANIFEST.MF" />
+    <property name="stress.manifest" value="${stress.build.classes}/MANIFEST.MF" />
 
     <target name="stress-build-test" depends="stress-build" description="Compile stress tests">
         <javac debug="true" debuglevel="${debuglevel}" destdir="${stress.test.classes}"
@@ -932,7 +932,7 @@
     </target>
 
     <target name="_stress_build">
-    	<mkdir dir="${stress.build.classes}" />
+        <mkdir dir="${stress.build.classes}" />
         <javac compiler="modern" debug="true" debuglevel="${debuglevel}"
                source="${source.version}" target="${target.version}"
                encoding="utf-8" destdir="${stress.build.classes}" includeantruntime="true">
@@ -990,7 +990,7 @@
     </target>
 
     <target name="_fqltool_build">
-    	<mkdir dir="${fqltool.build.classes}" />
+        <mkdir dir="${fqltool.build.classes}" />
         <javac compiler="modern" debug="true" debuglevel="${debuglevel}"
                source="${source.version}" target="${target.version}"
                encoding="utf-8" destdir="${fqltool.build.classes}" includeantruntime="true">
@@ -1007,15 +1007,15 @@
         </testmacro>
     </target>
 
-	<target name="_write-poms" depends="maven-declare-dependencies">
-	    <artifact:writepom pomRefId="parent-pom" file="${build.dir}/${final.name}-parent.pom"/>
-	    <artifact:writepom pomRefId="all-pom" file="${build.dir}/${final.name}.pom"/>
-	    <artifact:writepom pomRefId="build-deps-pom" file="${build.dir}/tmp-${final.name}-deps.pom"/>
-	</target>
+    <target name="_write-poms" depends="maven-declare-dependencies">
+        <artifact:writepom pomRefId="parent-pom" file="${build.dir}/${final.name}-parent.pom"/>
+        <artifact:writepom pomRefId="all-pom" file="${build.dir}/${final.name}.pom"/>
+        <artifact:writepom pomRefId="build-deps-pom" file="${build.dir}/tmp-${final.name}-deps.pom"/>
+    </target>
 
-	<target name="write-poms" unless="without.maven">
-	    <antcall target="_write-poms" />
-	</target>
+    <target name="write-poms" unless="without.maven">
+        <antcall target="_write-poms" />
+    </target>
 
     <!--
         The jar target makes cassandra.jar output.
@@ -1138,7 +1138,7 @@
       <copy todir="${dist.dir}/tools/">
         <fileset dir="${basedir}/tools/">
             <include name="*.yaml"/>
-	</fileset>
+    </fileset>
       </copy>
       <copy todir="${dist.dir}/tools/lib">
         <fileset dir="${build.dir}/tools/lib/">
@@ -2008,7 +2008,7 @@
   </natures>
 </projectDescription>]]>
     </echo>
-	<echo file=".classpath"><![CDATA[<?xml version="1.0" encoding="UTF-8"?>
+    <echo file=".classpath"><![CDATA[<?xml version="1.0" encoding="UTF-8"?>
 <classpath>
   <classpathentry kind="src" path="src/java"/>
   <classpathentry kind="src" path="src/resources"/>
@@ -2027,19 +2027,19 @@
   <classpathentry kind="lib" path="test/conf"/>
   <classpathentry kind="lib" path="${java.home}/../lib/tools.jar"/>
 ]]>
-	</echo>
-  	<path id="eclipse-project-libs-path">
-  	 <fileset dir="lib">
-  	    <include name="**/*.jar" />
+    </echo>
+      <path id="eclipse-project-libs-path">
+       <fileset dir="lib">
+          <include name="**/*.jar" />
      </fileset>
- 	 <fileset dir="build/lib/jars">
-  	    <include name="**/*.jar" />
-  	 </fileset>
+      <fileset dir="build/lib/jars">
+          <include name="**/*.jar" />
+       </fileset>
      <fileset dir="build/test/lib/jars">
         <include name="**/*.jar" />
      </fileset>
-  	</path>
-  	<property name="eclipse-project-libs" refid="eclipse-project-libs-path"/>
+      </path>
+      <property name="eclipse-project-libs" refid="eclipse-project-libs-path"/>
        <script language="javascript">
         <classpath>
             <path refid="cassandra.classpath"/>
@@ -2047,30 +2047,30 @@
         </classpath>
         <![CDATA[
         var File = java.io.File;
-  		var FilenameUtils = Packages.org.apache.commons.io.FilenameUtils;
-  		jars = project.getProperty("eclipse-project-libs").split(project.getProperty("path.separator"));
+          var FilenameUtils = Packages.org.apache.commons.io.FilenameUtils;
+          jars = project.getProperty("eclipse-project-libs").split(project.getProperty("path.separator"));
 
-  		cp = "";
-  	    for (i=0; i< jars.length; i++) {
-  	       srcjar = FilenameUtils.getBaseName(jars[i]) + '-sources.jar';
+          cp = "";
+          for (i=0; i< jars.length; i++) {
+             srcjar = FilenameUtils.getBaseName(jars[i]) + '-sources.jar';
            srcdir = FilenameUtils.concat(project.getProperty("build.test.dir"), 'sources');
-  		   srcfile = new File(FilenameUtils.concat(srcdir, srcjar));
+             srcfile = new File(FilenameUtils.concat(srcdir, srcjar));
 
-  		   cp += ' <classpathentry kind="lib" path="' + jars[i] + '"';
-  		   if (srcfile.exists()) {
-  		      cp += ' sourcepath="' + srcfile.getAbsolutePath() + '"';
-  		   }
-  		   cp += '/>\n';
-  		}
+             cp += ' <classpathentry kind="lib" path="' + jars[i] + '"';
+             if (srcfile.exists()) {
+                cp += ' sourcepath="' + srcfile.getAbsolutePath() + '"';
+             }
+             cp += '/>\n';
+          }
 
-  		cp += '</classpath>';
+          cp += '</classpath>';
 
-  		echo = project.createTask("echo");
-  	    echo.setMessage(cp);
-  		echo.setFile(new File(".classpath"));
-  		echo.setAppend(true);
-  	    echo.perform();
-  	]]> </script>
+          echo = project.createTask("echo");
+          echo.setMessage(cp);
+          echo.setFile(new File(".classpath"));
+          echo.setAppend(true);
+          echo.perform();
+      ]]> </script>
     <mkdir dir=".settings" />
   </target>
 
@@ -2084,8 +2084,8 @@
     <delete file=".project" />
     <delete file=".classpath" />
     <delete dir=".settings" />
-  	<delete dir=".externalToolBuilders" />
-  	<delete dir="build/eclipse-classes" />
+      <delete dir=".externalToolBuilders" />
+      <delete dir="build/eclipse-classes" />
   </target>
 
   <!-- ECJ 4.6.1 in standalone mode does not work with JPMS, so we skip this target for Java 11 -->
@@ -2098,18 +2098,18 @@
 
         <echo message="Running Eclipse Code Analysis.  Output logged to ${ecj.warnings.file}" />
 
-	<java
-	    jar="${build.dir.lib}/jars/ecj-${ecj.version}.jar"
+    <java
+        jar="${build.dir.lib}/jars/ecj-${ecj.version}.jar"
             fork="true"
-	    failonerror="true"
+        failonerror="true"
             maxmemory="512m">
             <arg value="-source"/>
-	    <arg value="${source.version}" />
-	    <arg value="-target"/>
-	    <arg value="${target.version}" />
-	    <arg value="-d" />
+        <arg value="${source.version}" />
+        <arg value="-target"/>
+        <arg value="${target.version}" />
+        <arg value="-d" />
             <arg value="none" />
-	    <arg value="-proc:none" />
+        <arg value="-proc:none" />
             <arg value="-log" />
             <arg value="${ecj.warnings.file}" />
             <arg value="-properties" />

--- a/pkg-descr
+++ b/pkg-descr
@@ -12,5 +12,3 @@ The CQL query language offers SQL-like data access and management.
 Drivers are available for a number of languages.
 
 This is a BETA version!
-
-WWW: https://cassandra.apache.org/

--- a/pkg-plist
+++ b/pkg-plist
@@ -95,6 +95,7 @@
 %%DATADIR%%/pylib/cqlshlib/util.py
 %%DATADIR%%/pylib/cqlshlib/wcwidth.py
 %%DATADIR%%/pylib/README.asc
+%%DATADIR%%/pylib/pytest.ini
 %%DATADIR%%/pylib/requirements.txt
 %%DATADIR%%/pylib/setup.py
 %%DATADIR%%/tools/bin/auditlogviewer


### PR DESCRIPTION
As stated in [Reproducible builds in FreeBSD](https://www.bsdcan.org/2016/schedule/attachments/375_2016-06-11-BSDCan-2016-Reproducible-Builds.pdf) `bsdtar` doesn't allow changing mtime, so I frist added a line to do this:

```
cd ${REPO_DIR} && ${FIND} . -print0 | xargs -0 touch -d 2022-08-08T20:40:04Z
```

This is not enough as file traversal order changes from time to time; to solve this I used `find -s` to produce a sorted file list:

```
cd ${WRKDIR} && \
${FIND} -s repository/ -print >list.txt && \
${TAR} czf ${DISTDIR}/apache-${PORTNAME}-${DISTVERSION}-repo.tar.gz -nT list.txt
```

Still not enough, as `gzip` header includes a timestamp; this can be solved by using [`gzip -n`](https://www.freebsd.org/cgi/man.cgi?query=gzip&sektion=1) but instead I tried two approaches and it seems to work fine with both:
1. using `7zz` (always sorts traversal order, so `list.txt` is not needed) `7zz a -mx9 ${DISTDIR}/apache-${PORTNAME}-${DISTVERSION}-repo.7z repository/`
2. using `xz` `${TAR} cJf ${DISTDIR}/apache-${PORTNAME}-${DISTVERSION}-repo.tar.xz -nT list.txt`

I decided for the latter as it is included in the base system.